### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -100,7 +100,7 @@ $ (cd jefferson && sudo python setup.py install)
 
 ```bash
 # Install ubi_reader to extract UBIFS file systems
-$ sudo apt-get install liblzo2-dev python-lzo
+$ sudo apt-get install liblzo2-dev
 $ git clone https://github.com/jrspruitt/ubi_reader
 $ (cd ubi_reader && sudo python setup.py install)
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,7 +59,7 @@ $ sudo pip install pyqtgraph
 
 ```bash
 # Python3.x
-$ sudo apt-get install libqt4-opengl python3-opengl python3-pyqt4 python3-pyqt4.qtopengl python3-numpy python3-scipy python3-pip
+$ sudo apt-get python3-opengl python3-numpy python3-scipy python3-pip
 $ sudo pip3 install pyqtgraph
 ```
 
@@ -81,7 +81,7 @@ Binwalk relies on multiple external utilties in order to automatically extract/d
 
 ```bash
 # Install standard extraction utilities
-$ sudo apt-get install mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-full cabextract cramfsprogs cramfsswap squashfs-tools sleuthkit default-jdk lzop srecord
+$ sudo apt-get install mtd-utils gzip bzip2 tar arj lhasa p7zip p7zip-full cabextract cramfsswap squashfs-tools sleuthkit default-jdk lzop srecord
 ```
 
 ```bash


### PR DESCRIPTION
Ubuntu 20.04, installing with python3, there appears to be errors related to locating package libqt4-opengl and some other errors, updated command to remove packages no longer applicable in Ubuntu 20.04

E: Unable to locate package libqt4-opengl
E: Unable to locate package python3-pyqt4
E: Package 'python3-pyqt4.qtopengl' has no installation candidate

E: Unable to locate package cramfsprogs

E: Unable to locate package python-lzo
